### PR TITLE
feat(strip-card): add configurable name_replace to sanitize friendly names

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,20 @@ lovelace:
 | `show_icon`           | `boolean`  | `false`                     | Displays the entity icon if true.                                               |
 | `unit_position`       | `string`   | `"right"`                   | Position of unit label relative to value. Options: `"left"` or `"right"`.     |
 
+### name_replace (optional)
+Allows removing or replacing parts of the friendly name via regular expressions.
+- `string`: treated as pattern with flags `gi`, replacement `""`.
+- `object`: `{ pattern: string, flags?: string, replace?: string }`.
+
+Example:
+
+```yaml
+name_replace:
+  - pattern: ' ?Offener Betrag'
+    flags: 'gi'
+    replace: ''
+```
+
 ## Color Options
 
 | **Option**      | **Default**                       | **Description**                           |


### PR DESCRIPTION
## Summary
- allow optional `name_replace` config to regex-replace parts of entity friendly names
- document new `name_replace` option in README

## Testing
- `npm install`
- `npm run build` *(fails: Missing script "build")*

------
https://chatgpt.com/codex/tasks/task_e_6897a84d8fec832eb00135e403828a3d